### PR TITLE
Sanitize crawler_source_id search term

### DIFF
--- a/src/nldi_crawler/cli.py
+++ b/src/nldi_crawler/cli.py
@@ -109,21 +109,22 @@ def download(ctx, source_id):
     """
     Download the data associated with a named data source.
     """
+    cid = sanitize_cid(source_id)
     logging.info(" Downloading source %s ", source_id)
     try:
-        source_list = source.fetch_source_table(ctx.obj["DB_URL"], selector=source_id)
+        source_list = source.fetch_source_table(ctx.obj["DB_URL"], selector=cid )
     except ConnectionError:
         sys.exit(-2)
 
     if len(source_list) == 0:
-        click.echo(f"No source found with ID {source_id}")
+        click.echo(f"No source found with ID {cid}")
         return
     fname = source.download_geojson(source_list[0])
     if fname:
-        click.echo(f"Source {source_id} downloaded to {fname}")
+        click.echo(f"Source {cid} downloaded to {fname}")
     else:
-        logging.warning("Download FAILED for source %s", source_id)
-        click.echo(f"Download FAILED for source {source_id}")
+        logging.warning("Download FAILED for source %s", cid)
+        click.echo(f"Download FAILED for source {cid}")
         sys.exit(-1)
 
 
@@ -134,6 +135,10 @@ def display(ctx, source_id):
     """
     Show details for named data source.
     """
+    cid = sanitize_cid(source_id)
+    if not cid:
+        return
+    
     try:
         source_list = source.fetch_source_table(ctx.obj["DB_URL"], selector=source_id)
     except ConnectionError:
@@ -261,3 +266,6 @@ def cfg_from_env() -> dict:
         # password is a special case.  There is no default; it must be explicitly set.
         env_cfg["NLDI_DB_PASS"] = os.environ.get("NLDI_DB_PASS")
     return env_cfg
+
+def sanitize_cid(input:str) -> str:
+    return re.sub( "\D*(\d+)\D*", "\g<1>", input)

--- a/src/nldi_crawler/source.py
+++ b/src/nldi_crawler/source.py
@@ -17,7 +17,7 @@ from ijson import items, JSONError
 
 from sqlalchemy import create_engine, String, Integer, select
 from sqlalchemy.orm import DeclarativeBase, Session, mapped_column
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, DataError
 
 
 @dataclasses.dataclass
@@ -111,6 +111,10 @@ def fetch_source_table(connect_string: str, selector="") -> list:
                 retval.append(source)
     except OperationalError as exc:
         logging.warning("Database connection error")
+        logging.warning(exc)
+        raise ConnectionError from exc
+    except DataError as exc:
+        logging.warning("Error with SELECT query")
         logging.warning(exc)
         raise ConnectionError from exc
     finally:

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -8,6 +8,7 @@ import os
 import pytest
 
 from nldi_crawler import source
+from nldi_crawler import cli
 
 
 def test_list_sources(connect_string):
@@ -57,3 +58,13 @@ def test_validate_single_source_fail(connect_string):
     # source ID=1 is known to timeout and fail validation
     result = source.validate_src(src)
     assert result[0] == False
+
+
+@pytest.mark.parametrize(
+    "source_id",
+    ["13", "013", "a 13", "13 a", "13; drop table features"],
+)
+def test_sanitize_cid(source_id):
+    """tests sanitization scheme for crawler_source_id"""
+    # Note -- sanitize_cid returns an integer, give a string input
+    assert cli.sanitize_cid(source_id) == 13


### PR DESCRIPTION

sanitizes/cleans the supplied search value for source_id.

In addition to some string manipulation, the result is cast as an integer to ensure that no SQL can be injected to the value. 