### PR TITLE
merge: ew-dev into python-port

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,4 +2,4 @@ include:
   - project: "wma/nhgf/nldi/mirror-pipelines"
     ref: "2023-05-12-r0"
     file: 
-      - "nldi-crawler-py.yml"
+      - "nldi-crawler.yml"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ LABEL maintainer2="Erik Wojtylko <ewojtylko@usgs.gov>"
 COPY ./docker/DOIRootCA2.cer /usr/local/share/ca-certificates/DOIRootCA2.crt
 RUN chmod 644 /usr/local/share/ca-certificates/DOIRootCA2.crt && update-ca-certificates
 
+# Issue check for DOIRootCA2.crt present in ca-certs
+ARG CA_BUNDLE_DESTINATION=/usr/local/share/ca-certificates/DOIRootCA2.crt
+RUN python -c "x=open('$CA_BUNDLE_DESTINATION').read(); y=open('/etc/ssl/certs/ca-certificates.crt').read(); exit(0) if x in y else exit(-1)"
+
+
 ENV PIP_CERT="/etc/ssl/certs/ca-certificates.crt" \
     SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt" \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM root-cert as ubuntu-base
 
 RUN mkdir -p /nldi-crawler-py
 WORKDIR /nldi-crawler-py
-RUN pip install -U pip setuptools
+RUN pip install --install-options="--jobs=4" -U pip setuptools
 RUN pip install poetry
 COPY . .
 RUN poetry install

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,6 @@ LABEL maintainer2="Erik Wojtylko <ewojtylko@usgs.gov>"
 COPY ./docker/DOIRootCA2.cer /usr/local/share/ca-certificates/DOIRootCA2.crt
 RUN chmod 644 /usr/local/share/ca-certificates/DOIRootCA2.crt && update-ca-certificates
 
-# Issue check for DOIRootCA2.crt present in ca-certs
-ARG CA_BUNDLE_DESTINATION=/usr/local/share/ca-certificates/DOIRootCA2.crt
-RUN python -c "x=open('$CA_BUNDLE_DESTINATION').read(); y=open('/etc/ssl/certs/ca-certificates.crt').read(); exit(0) if x in y else exit(-1)"
-
-
 ENV PIP_CERT="/etc/ssl/certs/ca-certificates.crt" \
     SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt" \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \
@@ -32,6 +27,7 @@ RUN mkdir -p /nldi-crawler-py
 WORKDIR /nldi-crawler-py
 
 # Running into issue with thread limits 'RuntimeError: can't start new thread'
+RUN pip install -U pip
 RUN pip install -U setuptools
 RUN pip install poetry
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM root-cert as ubuntu-base
 
 RUN mkdir -p /nldi-crawler-py
 WORKDIR /nldi-crawler-py
+RUN pip install -U pip setuptools
 RUN pip install poetry
 COPY . .
 RUN poetry install

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ FROM root-cert as ubuntu-base
 
 RUN mkdir -p /nldi-crawler-py
 WORKDIR /nldi-crawler-py
+
+# Running into issue with thread limits 'RuntimeError: can't start new thread'
 RUN pip install -U pip
 RUN pip install -U setuptools
 RUN pip install poetry

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ FROM root-cert as ubuntu-base
 
 RUN mkdir -p /nldi-crawler-py
 WORKDIR /nldi-crawler-py
-RUN pip install --install-options="--jobs=4" -U pip setuptools
 RUN pip install poetry
 COPY . .
 RUN poetry install

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN mkdir -p /nldi-crawler-py
 WORKDIR /nldi-crawler-py
 
 # Running into issue with thread limits 'RuntimeError: can't start new thread'
-RUN pip install -U pip
 RUN pip install -U setuptools
 RUN pip install poetry
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ FROM root-cert as ubuntu-base
 
 RUN mkdir -p /nldi-crawler-py
 WORKDIR /nldi-crawler-py
-RUN pip install -U pip setuptools
+RUN pip install -U pip
+RUN pip install -U setuptools
 RUN pip install poetry
 COPY . .
 RUN poetry install

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ LABEL maintainer2="Erik Wojtylko <ewojtylko@usgs.gov>"
 
 # Needs DOI Cert to work.  VPN is needed for artifactory image and cert is needed to pip install through vpn.
 COPY ./docker/DOIRootCA2.cer /usr/local/share/ca-certificates/DOIRootCA2.crt
-RUN chmod 644 /usr/local/share/ca-certificates/DOIRootCA2.crt && update-ca-certificates
+RUN chmod 644 /usr/local/share/ca-certificates/DOIRootCA2.crt
+RUN update-ca-certificates
 
 ENV PIP_CERT="/etc/ssl/certs/ca-certificates.crt" \
     SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt" \
@@ -25,10 +26,7 @@ FROM root-cert as ubuntu-base
 
 RUN mkdir -p /nldi-crawler-py
 WORKDIR /nldi-crawler-py
-
-# Running into issue with thread limits 'RuntimeError: can't start new thread'
-RUN pip install -U pip
-RUN pip install -U setuptools
+RUN pip install -U pip setuptools
 RUN pip install poetry
 COPY . .
 RUN poetry install

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ LABEL maintainer2="Erik Wojtylko <ewojtylko@usgs.gov>"
 
 # Needs DOI Cert to work.  VPN is needed for artifactory image and cert is needed to pip install through vpn.
 COPY ./docker/DOIRootCA2.cer /usr/local/share/ca-certificates/DOIRootCA2.crt
-RUN chmod 644 /usr/local/share/ca-certificates/DOIRootCA2.crt
-RUN update-ca-certificates
+RUN chmod 644 /usr/local/share/ca-certificates/DOIRootCA2.crt && update-ca-certificates
 
 ENV PIP_CERT="/etc/ssl/certs/ca-certificates.crt" \
     SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt" \


### PR DESCRIPTION
Resolves Issue #41 

Changes referenced [mirror pipeline](https://code.chs.usgs.gov/wma/nhgf/nldi/mirror-pipelines) to [nldi-crawler.yml](https://code.chs.usgs.gov/wma/nhgf/nldi/mirror-pipelines/-/blob/main/nldi-crawler.yml) from nldi-crawler-py.yml.

This will ensure that, even after this fork is merged with canonical main, the built image will go to the same [space in dev](https://us-west-2.console.aws.amazon.com/ecr/repositories/private/807615458658/nldi/crawler?region=us-west-2) and prod.