### PR TITLE
update: ref tag to 2023-08-08-r0 to dix docker version issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
   - project: "wma/nhgf/nldi/mirror-pipelines"
-    ref: "2023-05-12-r0"
+    ref: "2023-08-08-r0"
     file: 
       - "nldi-crawler.yml"


### PR DESCRIPTION
I failed to remember the [nldi-crawler.yml pipeline](https://code.chs.usgs.gov/wma/nhgf/nldi/mirror-pipelines/-/blob/2023-08-08-r0/nldi-crawler.yml?ref_type=tags) needs to reference an updates set from [Shared Resources](https://code.chs.usgs.gov/wma/nhgf/shared-resources).  Updated Mirror-Pipeline, cut a new tag, and now am pointing this gitlab-ci file to speak to that new tag.  

Should complete #41 